### PR TITLE
workersocket transport: terminate worker on close

### DIFF
--- a/src/util/workerSocket.js
+++ b/src/util/workerSocket.js
@@ -36,9 +36,7 @@ WorkerSocket.prototype.send = function(data) {
 };
 
 WorkerSocket.prototype.close = function() {
-  this.socket_.postMessage({
-    close: true
-  });
+  this.socket_.terminate();
 };
 
 module.exports = WorkerSocket;

--- a/src/util/workerSocketImpl.js
+++ b/src/util/workerSocketImpl.js
@@ -27,10 +27,7 @@ module.exports = function(self) {
       socket.send(data);
     } else {
       // control message
-      if (data.hasOwnProperty('close')) {
-        socket.close();
-        socket = null;
-      } else if (data.hasOwnProperty('uri')) {
+      if (data.hasOwnProperty('uri')) {
         var uri = data.uri;
 
         socket = new WebSocket(uri);


### PR DESCRIPTION
Ensure the worker is immediately terminated by calling `.terminate()` rather than relying on garbage collection (the worker was being retained for unknown reasons).