### PR TITLE
Json parsing error handling

### DIFF
--- a/src/core/Param.js
+++ b/src/core/Param.js
@@ -27,8 +27,9 @@ function Param(options) {
  *  * value - the value of the param from ROS.
  */
 Param.prototype.get = function(callback) {
+  var ros = this.ros;
   var paramClient = new Service({
-    ros : this.ros,
+    ros : ros,
     name : '/rosapi/get_param',
     serviceType : 'rosapi/GetParam'
   });
@@ -38,8 +39,12 @@ Param.prototype.get = function(callback) {
   });
 
   paramClient.callService(request, function(result) {
-    var value = JSON.parse(result.value);
-    callback(value);
+    try {
+      var value = JSON.parse(result.value);
+      callback(value);
+    } catch (e) {
+      ros.emit('error', 'Failed to parse JSON param value: ' + e.message);
+    }
   });
 };
 

--- a/src/core/SocketAdapter.js
+++ b/src/core/SocketAdapter.js
@@ -110,8 +110,12 @@ function SocketAdapter(client) {
         var decoded = CBOR.decode(data.data, typedArrayTagger);
         handleMessage(decoded);
       } else {
-        var message = JSON.parse(typeof data === 'string' ? data : data.data);
-        handleMessage(message);
+        try {
+          var message = JSON.parse(typeof data === 'string' ? data : data.data);
+          handleMessage(message);
+        } catch (e) {
+          client.emit('error', 'Failed to parse JSON rosbridge message: ' + e.message);
+        }
       }
     }
   };

--- a/test/json-parsing.test.js
+++ b/test/json-parsing.test.js
@@ -1,0 +1,102 @@
+var expect = require('chai').expect;
+var SocketAdapter = require('../src/core/SocketAdapter');
+
+describe('JSON Parsing Error Handling', function() {
+
+  describe('SocketAdapter', function() {
+
+    it('should emit an error event when receiving invalid JSON as a string', function(done) {
+      var client = {
+        transportOptions: {},
+        emit: function(event, data) {
+          if (event === 'error') {
+            expect(data).to.be.a('string');
+            expect(data).to.contain('Failed to parse JSON rosbridge message');
+            done();
+          }
+        }
+      };
+
+      var adapter = SocketAdapter(client);
+      adapter.onmessage('not valid json {{{');
+    });
+
+    it('should emit an error event when JSON contains NaN', function(done) {
+      var client = {
+        transportOptions: {},
+        emit: function(event, data) {
+          if (event === 'error') {
+            expect(data).to.be.a('string');
+            expect(data).to.contain('Failed to parse JSON rosbridge message');
+            done();
+          }
+        }
+      };
+
+      var adapter = SocketAdapter(client);
+      adapter.onmessage('{"value": NaN}');
+    });
+
+    it('should emit an error event when data.data contains invalid JSON', function(done) {
+      var client = {
+        transportOptions: {},
+        emit: function(event, data) {
+          if (event === 'error') {
+            expect(data).to.be.a('string');
+            expect(data).to.contain('Failed to parse JSON rosbridge message');
+            done();
+          }
+        }
+      };
+
+      var adapter = SocketAdapter(client);
+      adapter.onmessage({ data: '[1, NaN, 3]' });
+    });
+
+    it('should still handle valid JSON messages', function(done) {
+      var client = {
+        transportOptions: {},
+        emit: function(topic, msg) {
+          expect(topic).to.equal('/test_topic');
+          expect(msg.data).to.equal(42);
+          done();
+        }
+      };
+
+      var adapter = SocketAdapter(client);
+      adapter.onmessage({ data: '{"op":"publish","topic":"/test_topic","msg":{"data":42}}' });
+    });
+
+    it('should handle valid JSON string messages', function(done) {
+      var client = {
+        transportOptions: {},
+        emit: function(topic, msg) {
+          expect(topic).to.equal('/test_topic');
+          expect(msg.data).to.equal('hello');
+          done();
+        }
+      };
+
+      var adapter = SocketAdapter(client);
+      adapter.onmessage('{"op":"publish","topic":"/test_topic","msg":{"data":"hello"}}');
+    });
+
+    it('should not throw when receiving invalid JSON', function() {
+      var errorEmitted = false;
+      var client = {
+        transportOptions: {},
+        emit: function(event) {
+          if (event === 'error') {
+            errorEmitted = true;
+          }
+        }
+      };
+
+      var adapter = SocketAdapter(client);
+      expect(function() {
+        adapter.onmessage('{"values": [0.11920929, NaN, 0.479]}');
+      }).to.not.throw();
+      expect(errorEmitted).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
Add error handling for `JSON.parse` calls in `SocketAdapter` and `Param` to prevent application crashes caused by invalid JSON messages.

Previously, `JSON.parse` calls lacked error handling, leading to `SyntaxError` exceptions and application crashes when receiving malformed JSON, such as messages containing `NaN`.

---
<p><a href="https://cursor.com/agents/bc-b79a4c79-0da6-407b-89de-e1d972b1c902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b79a4c79-0da6-407b-89de-e1d972b1c902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

